### PR TITLE
Fix sticky Aubri heading

### DIFF
--- a/app/components/EventTimeline.tsx
+++ b/app/components/EventTimeline.tsx
@@ -17,6 +17,7 @@ export default function EventTimeline({ groupedEvents }: Props) {
               sticky top-0
               z-10
               py-2
+              ml-36
             "
           >
             <h2 className="text-4xl font-bold text-white drop-shadow-lg">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,12 +12,14 @@ export default async function Home() {
   const grouped = groupByDate(events);
 
   return (
-    <main className="relative z-10 p-6 max-w-6xl mx-auto">
+    <main className="relative z-10 pt-20 p-6 max-w-6xl mx-auto">
+      <h1
+        className="fixed left-6 top-6 z-20 text-5xl font-bold drop-shadow-lg text-shimmer-gold"
+      >
+        Aubri
+      </h1>
       <div className="flex justify-between items-center mb-8">
         <div>
-          <h1 className="text-4xl font-bold drop-shadow-lg text-shimmer-gold">
-            Aubri
-          </h1>
           <h1 className="text-4xl font-bold text-white drop-shadow-lg">
             SF Tech Events
           </h1>


### PR DESCRIPTION
## Summary
- keep the Aubri logo visible while scrolling
- slightly enlarge the Aubri logo
- offset timeline headings so they don't overlap the logo

## Testing
- `npm run lint` *(fails: `next` not found)*