### PR TITLE
Add Aubri logo and live match count visual

### DIFF
--- a/app/components/LiveMatchCount.tsx
+++ b/app/components/LiveMatchCount.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function LiveMatchCount() {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function fetchCount() {
+      try {
+        const res = await fetch('/api/match_count');
+        if (res.ok) {
+          const data = await res.json();
+          setCount(data.count);
+        }
+      } catch (err) {
+        console.error('Failed to load match count', err);
+      }
+    }
+
+    fetchCount();
+    const id = setInterval(fetchCount, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (count === null) {
+    return <p className="text-white">Loading match count...</p>;
+  }
+
+  return (
+    <div className="my-8 flex justify-center">
+      <div className="relative w-32 h-32 rounded-full border-8 border-pink-500 bg-white/80 backdrop-blur-md flex items-center justify-center shadow-lg">
+        <span className="text-4xl font-bold text-pink-600">{count}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,26 +1,25 @@
+
 'use client';
 
-import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import LiveMatchCount from '../components/LiveMatchCount';
 
 export default function MatchesPage() {
-  const [matchCount, setMatchCount] = useState<number | null>(null);
-
-  useEffect(() => {
-    fetch('/api/match-count')
-      .then((res) => res.json())
-      .then((data) => setMatchCount(data.count));
-  }, []);
 
   return (
     <main className="p-6 max-w-xl mx-auto text-center">
-      <h1 className="text-2xl font-bold mb-4 text-white drop-shadow-lg"> Matches Made</h1>
-      {matchCount === null ? (
-        <p>Loading match count...</p>
-      ) : (
-        <p className="text-xl font-medium">
-          <span className="text-pink-500 font-bold">{matchCount}</span> matches have been made so far!
-        </p>
-      )}
+      <Image
+        src="/images/aubri_logo_transparent.svg"
+        alt="Aubri logo"
+        width={120}
+        height={120}
+        className="mx-auto mb-4"
+      />
+
+      <h1 className="text-2xl font-bold mb-4 text-white drop-shadow-lg">Matches Made</h1>
+
+      <LiveMatchCount />
+
       <p className="mt-6 text-gray-700">
         If you recently signed up, check your email — we’ve introduced you to your buddy there!
       </p>


### PR DESCRIPTION
## Summary
- add a `LiveMatchCount` component with polling
- update the matches page with Aubri logo
- show the match count using the new component

## Testing
- `npm run lint` *(fails: `next` not found)*