### PR TITLE
Apply gold shimmer styles to matches page

### DIFF
--- a/app/components/LiveMatchCount.tsx
+++ b/app/components/LiveMatchCount.tsx
@@ -29,8 +29,8 @@ export default function LiveMatchCount() {
 
   return (
     <div className="my-8 flex justify-center">
-      <div className="relative w-32 h-32 rounded-full border-8 border-pink-500 bg-white/80 backdrop-blur-md flex items-center justify-center shadow-lg">
-        <span className="text-4xl font-bold text-pink-600">{count}</span>
+      <div className="relative w-32 h-32 rounded-full border-8 border-yellow-500 bg-white/80 backdrop-blur-md flex items-center justify-center shadow-lg">
+        <span className="text-4xl font-bold text-shimmer-gold">{count}</span>
       </div>
     </div>
   );

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,22 +1,17 @@
 
 'use client';
 
-import Image from 'next/image';
 import LiveMatchCount from '../components/LiveMatchCount';
 
 export default function MatchesPage() {
 
   return (
     <main className="p-6 max-w-xl mx-auto text-center">
-      <Image
-        src="/images/aubri_logo_transparent.svg"
-        alt="Aubri logo"
-        width={120}
-        height={120}
-        className="mx-auto mb-4"
-      />
+      <h1 className="text-5xl font-bold mb-4 drop-shadow-lg text-shimmer-gold">
+        Aubri
+      </h1>
 
-      <h1 className="text-2xl font-bold mb-4 text-white drop-shadow-lg">Matches Made</h1>
+      <h2 className="text-2xl font-bold mb-4 text-white drop-shadow-lg">Matches Made</h2>
 
       <LiveMatchCount />
 


### PR DESCRIPTION
## Summary
- restyle Matches page header with shimmering gold
- display match count in dynamic gold and adjust border color

## Testing
- `npm run lint` *(fails: `next` not found)*