### PR TITLE
Tweak background colors to reduce white

### DIFF
--- a/app/components/MeshGradient.tsx
+++ b/app/components/MeshGradient.tsx
@@ -23,7 +23,7 @@ export default function MeshGradient() {
         '--gradient-color-1': '#dca8d8',
         '--gradient-color-2': '#a3d3f9',
         '--gradient-color-3': '#fcd6d6',
-        '--gradient-color-4': '#ffffff',
+        '--gradient-color-4': '#dca8d8',
       }as any}
     />
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: linear-gradient(-45deg, #ffd1dc, #ffe4e6, #fbcfe8, #e0f2fe);
+  background: linear-gradient(-45deg, #ffd1dc, #fcd6d6, #fbcfe8, #e0f2fe);
   background-size: 400% 400%;
   animation: gradientMorph 15s ease infinite;
   font-family: var(--font-sans);


### PR DESCRIPTION
## Summary
- reduce the white color in the dynamic mesh gradient
- adjust the global background gradient to use a pink shade instead of white

## Testing
- `npm run lint` *(fails: next not found)*