### PR TITLE
Add homepage links and new subpages

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,42 @@
+// app/events/page.tsx
+
+import { fetchAllEvents, LumaEvent } from "@/lib/luma";
+import { groupByDate }               from "@/lib/groupByDate";
+import EventTimeline                 from "../components/EventTimeline";
+
+export default async function Home() {
+  // 1) Fetch all events on the server
+  const events: LumaEvent[] = await fetchAllEvents();
+
+  // 2) Group them by the day string
+  const grouped = groupByDate(events);
+
+  return (
+    <main className="relative z-10 pt-20 p-6 max-w-6xl mx-auto">
+      <h1
+        className="fixed left-6 top-6 z-20 text-5xl font-bold drop-shadow-lg text-shimmer-gold"
+      >
+        Aubri
+      </h1>
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-4xl font-bold text-white drop-shadow-lg">
+            SF Tech Events
+          </h1>
+        </div>
+        <a
+          href="/matches"
+          className="text-2xl font-bold text-white drop-shadow-lg"
+        >
+          See matches made
+        </a>
+      </div>
+
+      {events.length === 0 ? (
+        <p className="text-white">Loading events…</p>
+      ) : (
+        <EventTimeline groupedEvents={grouped} />
+      )}
+    </main>
+  );
+}

--- a/app/gals/page.tsx
+++ b/app/gals/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function GalsPage() {
+  return (
+    <main className="p-6 max-w-xl mx-auto text-center">
+      <h1 className="text-5xl font-bold mb-4 drop-shadow-lg text-shimmer-gold">Aubri</h1>
+      <h2 className="text-2xl font-bold mb-4 text-white drop-shadow-lg">SF Gals Get Together</h2>
+      <p className="text-gray-700">More fun activities coming soon!</p>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,42 +1,17 @@
-// app/page.tsx
+'use client';
 
-import { fetchAllEvents, LumaEvent } from "@/lib/luma";
-import { groupByDate }               from "@/lib/groupByDate";
-import EventTimeline                 from "./components/EventTimeline";
-
-export default async function Home() {
-  // 1) Fetch all events on the server
-  const events: LumaEvent[] = await fetchAllEvents();
-
-  // 2) Group them by the day string
-  const grouped = groupByDate(events);
-
+export default function HomePage() {
   return (
-    <main className="relative z-10 pt-20 p-6 max-w-6xl mx-auto">
-      <h1
-        className="fixed left-6 top-6 z-20 text-5xl font-bold drop-shadow-lg text-shimmer-gold"
-      >
-        Aubri
-      </h1>
-      <div className="flex justify-between items-center mb-8">
-        <div>
-          <h1 className="text-4xl font-bold text-white drop-shadow-lg">
-            SF Tech Events
-          </h1>
-        </div>
-        <a
-          href="/matches"
-          className="text-2xl font-bold text-white drop-shadow-lg"
-        >
-          See matches made
+    <main className="flex flex-col items-center justify-center min-h-screen p-6 space-y-8 text-center">
+      <h1 className="text-5xl font-bold drop-shadow-lg text-shimmer-gold">Aubri</h1>
+      <div className="space-y-4">
+        <a href="/events" className="text-2xl font-bold text-white underline drop-shadow-lg">
+          SF Tech Events
+        </a>
+        <a href="/gals" className="text-2xl font-bold text-white underline drop-shadow-lg">
+          SF Gals Get Together
         </a>
       </div>
-
-      {events.length === 0 ? (
-        <p className="text-white">Loading events…</p>
-      ) : (
-        <EventTimeline groupedEvents={grouped} />
-      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- move events list to `/events`
- add new homepage with links to SF Tech Events and SF Gals Get Together pages
- create stub page for "SF Gals Get Together"

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c20bfe348322a0cad19ca0d3285a